### PR TITLE
"place cursor here" now converts to Keyboard Maestro and readme additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
-# textexpander_to_keyboardmaestro
+# Convert TextExpander snippets to Keyboard Maestro macros
+
+Simple batch convert of all your Snippets to Macros.
+
+### Usage
+
+Download the script and read the comments and make any changed before running the script with
+
+`$ python TE.py`
+
+### Notes
+
+This script will copy the snippets as they are, but doesn't convert any of the fancy features (fillPopups etc) from TextExpander automatically.
+
+So if TextExpander you have a snippet where it prompts you with a dropdown lise so:
+
+`@include breakpoint(%fillpopup:name=size:$small:$medium:default=$large:$xlarge%) {%|}`
+
+Then that will be what Keyboard Maestro will paste (or type depending on your settings).
+
+The fillpop won't work, so be sure to go through manually if you have fancy snippets.
+
+## Insert cursor here
+
+Included a find and replace for plaintext snippets allowing the "place cursor here" to work in Keyboard Maestro. The string in TextExpander to place cursor is `%|` and in Keyboard Maestro it is `%|%`
+
+Although the find and replace would work with the other snippet types it woudln't work if you opt to have the snippet typed rather than pasted.
+
+If you don't then replace
+
+ `'Text': text,`
+
+ with
+
+ `'Text': text.replace("%|", "%|%", 1),`
+
+You may want to do a find and replace for `%clipboard` replace with `%PastClipboard%1%` if you use "insert clipboard".
+
+You can also drag your Settings.textexpandersettings file into Sublime and do a find and replace on the whole folder to replace TextExpander variables with the equivalent for Keyboard Maestro.
+
+

--- a/TE.py
+++ b/TE.py
@@ -141,7 +141,7 @@ class KeyboardMaestroMacros(object):
                     'IsDisclosed': True,
                     'MacroActionType': 'InsertText',
                     'Paste': True,
-                    'Text': text}, {
+                    'Text': text.replace("%|", "%|%", 1)}, {
                         'IsActive': True,
                         'IsDisclosed': True,
                         'MacroActionType': 'DeletePastClipboard',


### PR DESCRIPTION
Thanks for you script, saved me loads of time. However because I used "place cursor here" quite a bit in TextExpander, I wanted that to convert across so added a simple find and replace to do so.

If the repo is the definitive version then it might be an idea to take the gist off your blog or change it to point people here. Because I originally discovered your script from a [LifeHacker article](http://lifehacker.com/move-textexpander-snippets-to-keyboard-maestro-with-thi-1771013442) that linked to the Gist and your blog and it wasn't super clear what was the most recent version :)

Thanks again
